### PR TITLE
Implement basic registration with email verification

### DIFF
--- a/Pages/ArticleView.razor
+++ b/Pages/ArticleView.razor
@@ -1,5 +1,6 @@
 @page "/article/{id}"
 @inject ArticleService ArticleService
+@inject AuthService AuthService
 
 <h1>@article?.Title</h1>
 
@@ -10,7 +11,10 @@
 else
 {
     <div class="mb-3">@((MarkupString)article.Content)</div>
-    <NavLink class="btn btn-secondary" href=@($"/edit-article/{id}")>Edit</NavLink>
+    @if (AuthService.IsInRole("Administrator") || AuthService.IsInRole("Editor"))
+    {
+        <NavLink class="btn btn-secondary" href=@($"/edit-article/{id}")>Edit</NavLink>
+    }
 }
 
 @code {

--- a/Pages/Articles.razor
+++ b/Pages/Articles.razor
@@ -1,10 +1,14 @@
 @page "/articles"
 @inject NavigationManager Navigation
 @inject ArticleService ArticleService
+@inject AuthService AuthService
 
 <h1>Articles</h1>
 
-<button class="btn btn-primary" @onclick="CreateNew">New Article</button>
+@if (AuthService.IsInRole("Administrator") || AuthService.IsInRole("Editor"))
+{
+    <button class="btn btn-primary" @onclick="CreateNew">New Article</button>
+}
 
 @if (articles == null)
 {

--- a/Pages/Counter.razor
+++ b/Pages/Counter.razor
@@ -1,4 +1,6 @@
 @page "/counter"
+@inject AuthService AuthService
+@inject NavigationManager Navigation
 
 <h1>Counter</h1>
 
@@ -13,5 +15,13 @@
     private void IncrementCount()
     {
         currentCount++;
+    }
+
+    protected override void OnInitialized()
+    {
+        if (AuthService.IsInRole("Reader") || string.IsNullOrEmpty(AuthService.Role))
+        {
+            Navigation.NavigateTo("/articles");
+        }
     }
 }

--- a/Pages/CreateEditor.razor
+++ b/Pages/CreateEditor.razor
@@ -1,0 +1,54 @@
+@page "/create-editor"
+@inject AuthService AuthService
+@inject NavigationManager Navigation
+
+<h1>Create Editor</h1>
+
+@if (!AuthService.IsInRole("Administrator"))
+{
+    <p>You are not authorized to view this page.</p>
+}
+else if (!created)
+{
+    if (!string.IsNullOrEmpty(error))
+    {
+        <div class="alert alert-danger">@error</div>
+    }
+    <EditForm Model="this" OnValidSubmit="HandleCreate">
+        <DataAnnotationsValidator />
+        <ValidationSummary />
+        <div class="mb-3">
+            <label class="form-label">Username</label>
+            <InputText class="form-control" @bind-Value="username" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Password</label>
+            <InputText type="password" class="form-control" @bind-Value="password" />
+        </div>
+        <button type="submit" class="btn btn-primary">Create</button>
+    </EditForm>
+}
+else
+{
+    <p>Editor created.</p>
+}
+
+@code {
+    private string username = string.Empty;
+    private string password = string.Empty;
+    private bool created;
+    private string? error;
+
+    private async Task HandleCreate()
+    {
+        var result = await AuthService.AddEditorAsync(username, password);
+        if (!result)
+        {
+            error = "Username already exists.";
+        }
+        else
+        {
+            created = true;
+        }
+    }
+}

--- a/Pages/EditArticle.razor
+++ b/Pages/EditArticle.razor
@@ -1,6 +1,7 @@
 @page "/edit-article/{id}"
 @inject ArticleService ArticleService
 @inject NavigationManager Navigation
+@inject AuthService AuthService
 
 <h1>Edit Article</h1>
 
@@ -31,6 +32,14 @@ else
     public string id { get; set; } = string.Empty;
 
     private Article? article;
+
+    protected override void OnInitialized()
+    {
+        if (!(AuthService.IsInRole("Administrator") || AuthService.IsInRole("Editor")))
+        {
+            Navigation.NavigateTo($"/article/{id}");
+        }
+    }
 
     protected override async Task OnParametersSetAsync()
     {

--- a/Pages/FetchData.razor
+++ b/Pages/FetchData.razor
@@ -1,6 +1,8 @@
 @page "/fetchdata"
 @using FoodBlog.Data
 @inject HttpClient Http
+@inject AuthService AuthService
+@inject NavigationManager Navigation
 
 <h1>Weather forecast</h1>
 
@@ -41,6 +43,11 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        if (AuthService.IsInRole("Reader") || string.IsNullOrEmpty(AuthService.Role))
+        {
+            Navigation.NavigateTo("/articles");
+            return;
+        }
         forecasts = await Http.GetFromJsonAsync<WeatherForecast[]>("sample-data/weather.json");
     }
 }

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -1,6 +1,18 @@
 @page "/"
+@inject AuthService AuthService
+@inject NavigationManager Navigation
 
 <h1>Welcome to FoodBlog</h1>
 
 <p>This is the home page.</p>
+
+@code {
+    protected override void OnInitialized()
+    {
+        if (AuthService.IsInRole("Reader") || string.IsNullOrEmpty(AuthService.Role))
+        {
+            Navigation.NavigateTo("/articles");
+        }
+    }
+}
 

--- a/Pages/Login.razor
+++ b/Pages/Login.razor
@@ -1,0 +1,62 @@
+@page "/login"
+@inject AuthService AuthService
+@inject NavigationManager Navigation
+
+<h1>Login</h1>
+
+@if (loggedIn)
+{
+    <p>You are logged in as @AuthService.Username (@AuthService.Role).</p>
+    <button class="btn btn-primary" @onclick="Logout">Logout</button>
+}
+else
+{
+    if (!string.IsNullOrEmpty(error))
+    {
+        <div class="alert alert-danger">@error</div>
+    }
+    <EditForm Model="this" OnValidSubmit="HandleLogin">
+        <DataAnnotationsValidator />
+        <ValidationSummary />
+        <div class="mb-3">
+            <label class="form-label">Username</label>
+            <InputText class="form-control" @bind-Value="username" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Password</label>
+            <InputText type="password" class="form-control" @bind-Value="password" />
+        </div>
+        <button type="submit" class="btn btn-primary">Login</button>
+    </EditForm>
+    <p class="mt-2">Don't have an account? <NavLink href="/register">Register</NavLink></p>
+}
+
+@code {
+    private string username = string.Empty;
+    private string password = string.Empty;
+    private string? error;
+
+    private bool loggedIn => !string.IsNullOrEmpty(AuthService.Username);
+
+    private async Task HandleLogin()
+    {
+        var result = await AuthService.LoginAsync(username, password);
+        if (!result)
+        {
+            error = AuthService.LastError;
+            if (error == "Account not verified.")
+            {
+                error += $" <a href='/verify?user={username}'>Verify here</a>";
+            }
+        }
+        else
+        {
+            Navigation.NavigateTo("/");
+        }
+    }
+
+    private async Task Logout()
+    {
+        await AuthService.LogoutAsync();
+    }
+}

--- a/Pages/NewArticle.razor
+++ b/Pages/NewArticle.razor
@@ -1,6 +1,7 @@
 @page "/new-article"
 @inject ArticleService ArticleService
 @inject NavigationManager Navigation
+@inject AuthService AuthService
 
 <h1>New Article</h1>
 
@@ -24,6 +25,14 @@
 
 @code {
     private Article article = new();
+
+    protected override void OnInitialized()
+    {
+        if (!(AuthService.IsInRole("Administrator") || AuthService.IsInRole("Editor")))
+        {
+            Navigation.NavigateTo("/articles");
+        }
+    }
 
     private async Task HandleValidSubmit()
     {

--- a/Pages/Register.razor
+++ b/Pages/Register.razor
@@ -1,0 +1,76 @@
+@page "/register"
+@inject AuthService AuthService
+@inject NavigationManager Navigation
+
+<h1>Register</h1>
+
+@if (!registered)
+{
+    if (!string.IsNullOrEmpty(error))
+    {
+        <div class="alert alert-danger">@error</div>
+    }
+    <EditForm Model="this" OnValidSubmit="HandleRegister">
+        <DataAnnotationsValidator />
+        <ValidationSummary />
+        <div class="mb-3">
+            <label class="form-label">Username</label>
+            <InputText class="form-control" @bind-Value="username" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Password</label>
+            <InputText type="password" class="form-control" @bind-Value="password" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Email</label>
+            <InputText type="email" class="form-control" @bind-Value="email" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">What is @numA + @numB?</label>
+            <InputNumber int? class="form-control" @bind-Value="robotAnswer" />
+        </div>
+        <button type="submit" class="btn btn-primary">Register</button>
+    </EditForm>
+}
+else
+{
+    <p>Registration successful! A verification code has been sent to your email.</p>
+    <p><strong>Code: @verificationCode</strong></p>
+    <NavLink href=@($"/verify?user={username}")>Verify account</NavLink>
+}
+
+@code {
+    private string username = string.Empty;
+    private string password = string.Empty;
+    private string email = string.Empty;
+    private int numA;
+    private int numB;
+    private int? robotAnswer;
+    private string? error;
+    private bool registered = false;
+    private string? verificationCode;
+
+    protected override void OnInitialized()
+    {
+        var rnd = new Random();
+        numA = rnd.Next(1, 10);
+        numB = rnd.Next(1, 10);
+    }
+
+    private async Task HandleRegister()
+    {
+        if (robotAnswer != numA + numB)
+        {
+            error = "Incorrect robot verification.";
+            return;
+        }
+        var code = await AuthService.RegisterReaderAsync(username, password, email);
+        if (code == null)
+        {
+            error = "Username already exists.";
+            return;
+        }
+        verificationCode = code;
+        registered = true;
+    }
+}

--- a/Pages/Sudoku.razor
+++ b/Pages/Sudoku.razor
@@ -1,4 +1,6 @@
 @page "/sudoku"
+@inject AuthService AuthService
+@inject NavigationManager Navigation
 
 <h1>Sudoku</h1>
 <p>Fill in the puzzle by selecting a cell and then a number.</p>
@@ -48,6 +50,11 @@
 
     protected override void OnInitialized()
     {
+        if (AuthService.IsInRole("Reader") || string.IsNullOrEmpty(AuthService.Role))
+        {
+            Navigation.NavigateTo("/articles");
+            return;
+        }
         for (int i = 0; i < 9; i++)
         {
             board[i] = new string[9];

--- a/Pages/VerifyEmail.razor
+++ b/Pages/VerifyEmail.razor
@@ -1,0 +1,62 @@
+@page "/verify"
+@inject AuthService AuthService
+@inject NavigationManager Navigation
+
+<h1>Verify Email</h1>
+
+@if (!verified)
+{
+    if (!string.IsNullOrEmpty(error))
+    {
+        <div class="alert alert-danger">@error</div>
+    }
+    <EditForm Model="this" OnValidSubmit="HandleVerify">
+        <DataAnnotationsValidator />
+        <ValidationSummary />
+        <div class="mb-3">
+            <label class="form-label">Username</label>
+            <InputText class="form-control" @bind-Value="username" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Verification Code</label>
+            <InputText class="form-control" @bind-Value="code" />
+        </div>
+        <button type="submit" class="btn btn-primary">Verify</button>
+    </EditForm>
+}
+else
+{
+    <p>Account verified. You can now <NavLink href="/login">log in</NavLink>.</p>
+}
+
+@code {
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "user")]
+    public string? UserQuery { get; set; }
+
+    private string username = string.Empty;
+    private string code = string.Empty;
+    private bool verified;
+    private string? error;
+
+    protected override void OnInitialized()
+    {
+        if (!string.IsNullOrEmpty(UserQuery))
+        {
+            username = UserQuery;
+        }
+    }
+
+    private async Task HandleVerify()
+    {
+        var result = await AuthService.VerifyEmailAsync(username, code);
+        if (!result)
+        {
+            error = "Invalid code.";
+        }
+        else
+        {
+            verified = true;
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using FoodBlog;
 using FoodBlog.Data;
+using FoodBlog.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -9,8 +10,11 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddSingleton<ArticleService>();
+builder.Services.AddSingleton<AuthService>();
 var host = builder.Build();
 var articleService = host.Services.GetRequiredService<ArticleService>();
 await articleService.InitializeAsync();
+var authService = host.Services.GetRequiredService<AuthService>();
+await authService.InitializeAsync();
 
 await host.RunAsync();

--- a/README.md
+++ b/README.md
@@ -24,3 +24,25 @@ dotnet watch run
 ```
 
 The application will be available locally and reload on file changes.
+
+## Authentication
+
+The sample now includes a very simple login system stored in the browser's local storage. Three roles are supported:
+
+- **Administrator** – full access to all pages
+- **Editor** – can create and edit articles
+- **Reader** – can only view articles and does not see the navigation menu
+
+Use the **Login** page to choose a username and role. Logging out clears the saved credentials.
+
+### User accounts
+
+A default administrator account is created automatically:
+
+- **Username:** `Admin`
+- **Password:** `Admin1`
+
+Administrators can create editor accounts from the **Create Editor** page. Regular
+readers register through the **Register** page. A simple math question prevents
+bot signups and a verification code must be entered on the **Verify** page
+before a reader can log in.

--- a/Services/AuthService.cs
+++ b/Services/AuthService.cs
@@ -1,0 +1,181 @@
+using System.Text.Json;
+using Microsoft.JSInterop;
+
+namespace FoodBlog.Services;
+
+public class AuthService
+{
+    private const string CurrentUserKey = "foodblog_user";
+    private const string UsersKey = "foodblog_users";
+
+    private readonly IJSRuntime _js;
+    private List<UserAccount> _users = new();
+
+    public AuthService(IJSRuntime js)
+    {
+        _js = js;
+    }
+
+    public string? Username { get; private set; }
+    public string? Role { get; private set; }
+    public string? LastError { get; private set; }
+
+    public event Action? AuthStateChanged;
+
+    public async Task InitializeAsync()
+    {
+        await LoadUsersAsync();
+        await LoadCurrentAsync();
+    }
+
+    private async Task LoadUsersAsync()
+    {
+        try
+        {
+            var json = await _js.InvokeAsync<string>("localStorage.getItem", UsersKey);
+            if (!string.IsNullOrEmpty(json))
+            {
+                var users = JsonSerializer.Deserialize<List<UserAccount>>(json);
+                if (users != null)
+                    _users = users;
+            }
+        }
+        catch
+        {
+            // ignore
+        }
+
+        if (!_users.Any(u => u.Role == "Administrator"))
+        {
+            _users.Add(new UserAccount
+            {
+                Username = "Admin",
+                Password = "Admin1",
+                Role = "Administrator",
+                Verified = true
+            });
+            await SaveUsersAsync();
+        }
+    }
+
+    private async Task LoadCurrentAsync()
+    {
+        try
+        {
+            var json = await _js.InvokeAsync<string>("localStorage.getItem", CurrentUserKey);
+            if (!string.IsNullOrEmpty(json))
+            {
+                var user = JsonSerializer.Deserialize<UserInfo>(json);
+                if (user != null)
+                {
+                    Username = user.Username;
+                    Role = user.Role;
+                }
+            }
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    private async Task SaveUsersAsync()
+    {
+        var json = JsonSerializer.Serialize(_users);
+        await _js.InvokeVoidAsync("localStorage.setItem", UsersKey, json);
+    }
+
+    public async Task<bool> LoginAsync(string username, string password)
+    {
+        LastError = null;
+        var user = _users.FirstOrDefault(u => u.Username == username && u.Password == password);
+        if (user == null)
+        {
+            LastError = "Invalid username or password.";
+            return false;
+        }
+        if (user.Role == "Reader" && !user.Verified)
+        {
+            LastError = "Account not verified.";
+            return false;
+        }
+        Username = user.Username;
+        Role = user.Role;
+        var json = JsonSerializer.Serialize(new UserInfo { Username = Username!, Role = Role! });
+        await _js.InvokeVoidAsync("localStorage.setItem", CurrentUserKey, json);
+        AuthStateChanged?.Invoke();
+        return true;
+    }
+
+    public async Task LogoutAsync()
+    {
+        Username = null;
+        Role = null;
+        await _js.InvokeVoidAsync("localStorage.removeItem", CurrentUserKey);
+        AuthStateChanged?.Invoke();
+    }
+
+    public bool IsInRole(string role) => string.Equals(Role, role, StringComparison.OrdinalIgnoreCase);
+
+    public bool UserExists(string username) => _users.Any(u => u.Username == username);
+
+    public async Task<string?> RegisterReaderAsync(string username, string password, string email)
+    {
+        if (UserExists(username))
+            return null;
+        var code = new Random().Next(100000, 999999).ToString();
+        _users.Add(new UserAccount
+        {
+            Username = username,
+            Password = password,
+            Role = "Reader",
+            Email = email,
+            Verified = false,
+            VerificationCode = code
+        });
+        await SaveUsersAsync();
+        return code;
+    }
+
+    public async Task<bool> VerifyEmailAsync(string username, string code)
+    {
+        var user = _users.FirstOrDefault(u => u.Username == username && u.Role == "Reader");
+        if (user == null || user.Verified || user.VerificationCode != code)
+            return false;
+        user.Verified = true;
+        user.VerificationCode = null;
+        await SaveUsersAsync();
+        return true;
+    }
+
+    public async Task<bool> AddEditorAsync(string username, string password)
+    {
+        if (UserExists(username))
+            return false;
+        _users.Add(new UserAccount
+        {
+            Username = username,
+            Password = password,
+            Role = "Editor",
+            Verified = true
+        });
+        await SaveUsersAsync();
+        return true;
+    }
+
+    private class UserInfo
+    {
+        public string Username { get; set; } = string.Empty;
+        public string Role { get; set; } = string.Empty;
+    }
+
+    private class UserAccount
+    {
+        public string Username { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+        public string Role { get; set; } = string.Empty;
+        public string? Email { get; set; }
+        public bool Verified { get; set; }
+        public string? VerificationCode { get; set; }
+    }
+}

--- a/Shared/MainLayout.razor
+++ b/Shared/MainLayout.razor
@@ -1,14 +1,28 @@
 @inherits LayoutComponentBase
+@inject AuthService AuthService
+@implements IDisposable
 
 <PageTitle>FoodBlog</PageTitle>
 
-<header class="header">
-    <h1>FoodBlog</h1>
+<header class="header d-flex align-items-center px-2">
+    <h1 class="me-auto">FoodBlog</h1>
+    @if (string.IsNullOrEmpty(AuthService.Username))
+    {
+        <NavLink class="text-white" href="/login">Login</NavLink>
+    }
+    else
+    {
+        <span class="text-white me-2">@AuthService.Username (@AuthService.Role)</span>
+        <a href="#" class="text-white" @onclick="Logout">Logout</a>
+    }
 </header>
 
 <div class="page">
-    <NavMenu />
-    <main class="main-content">
+    @if (!AuthService.IsInRole("Reader"))
+    {
+        <NavMenu />
+    }
+    <main class="main-content" style="margin-left:@(AuthService.IsInRole("Reader") ? "0" : "200px")">
         <article class="content px-4">
             @Body
         </article>
@@ -17,3 +31,25 @@
         </footer>
     </main>
 </div>
+
+@code {
+    protected override void OnInitialized()
+    {
+        AuthService.AuthStateChanged += OnAuthStateChanged;
+    }
+
+    private void OnAuthStateChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    private async Task Logout()
+    {
+        await AuthService.LogoutAsync();
+    }
+
+    public void Dispose()
+    {
+        AuthService.AuthStateChanged -= OnAuthStateChanged;
+    }
+}

--- a/Shared/NavMenu.razor
+++ b/Shared/NavMenu.razor
@@ -1,3 +1,4 @@
+@inject AuthService AuthService
 <nav class="sidebar">
     <ul>
         <li>
@@ -15,5 +16,11 @@
         <li>
             <NavLink href="articles">Articles</NavLink>
         </li>
+        @if (AuthService.IsInRole("Administrator"))
+        {
+            <li>
+                <NavLink href="create-editor">Create Editor</NavLink>
+            </li>
+        }
     </ul>
 </nav>

--- a/_Imports.razor
+++ b/_Imports.razor
@@ -9,3 +9,4 @@
 @using FoodBlog
 @using FoodBlog.Shared
 @using FoodBlog.Data
+@using FoodBlog.Services


### PR DESCRIPTION
## Summary
- introduce local user store and default admin credentials
- add registration page with math captcha and email verification flow
- add page for administrators to create editor accounts
- update login to use stored credentials
- expose create-editor link for admins in the nav menu
- document new auth workflow in README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869559568e0832aaebaf430c47994fb