### PR TITLE
Fix math input on registration

### DIFF
--- a/Pages/CreateEditor.razor
+++ b/Pages/CreateEditor.razor
@@ -8,8 +8,12 @@
 {
     <p>You are not authorized to view this page.</p>
 }
-else if (!created)
+else
 {
+    if (created)
+    {
+        <div class="alert alert-success">Editor created.</div>
+    }
     if (!string.IsNullOrEmpty(error))
     {
         <div class="alert alert-danger">@error</div>
@@ -28,10 +32,6 @@ else if (!created)
         <button type="submit" class="btn btn-primary">Create</button>
     </EditForm>
 }
-else
-{
-    <p>Editor created.</p>
-}
 
 @code {
     private string username = string.Empty;
@@ -49,6 +49,9 @@ else
         else
         {
             created = true;
+            error = null;
+            username = string.Empty;
+            password = string.Empty;
         }
     }
 }

--- a/Pages/Register.razor
+++ b/Pages/Register.razor
@@ -27,7 +27,7 @@
         </div>
         <div class="mb-3">
             <label class="form-label">What is @numA + @numB?</label>
-            <InputNumber int? class="form-control" @bind-Value="robotAnswer" />
+            <InputNumber TValue="int?" class="form-control" @bind-Value="robotAnswer" />
         </div>
         <button type="submit" class="btn btn-primary">Register</button>
     </EditForm>

--- a/README.md
+++ b/README.md
@@ -45,4 +45,9 @@ A default administrator account is created automatically:
 Administrators can create editor accounts from the **Create Editor** page. Regular
 readers register through the **Register** page. A simple math question prevents
 bot signups and a verification code must be entered on the **Verify** page
-before a reader can log in.
+before a reader can log in. Enter the answer to the math question in the numeric
+field below the email input when registering.
+
+To create an editor account, log in with the administrator credentials above and
+navigate to `/create-editor` (available from the navigation menu). The page lets
+you choose a username and password for the new editor.

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -65,6 +65,11 @@ body {
     margin-left: 200px;
     flex: 1;
     padding: 1rem;
+    background-color: #fff;
+}
+
+.content {
+    background-color: #fff;
 }
 
 .sudoku-board {


### PR DESCRIPTION
## Summary
- ensure the Register page shows a numeric field for the math question
- note how to answer the math question in the README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869ab8a36e4832aaa71af12e7cfbea2